### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           #apt-get install -y python3-pip
           python3 -m pip install --upgrade pip
-          pip install -U platformio
+          pip install -U platformio --break-system-packages
       - name: Build
         run: |
           pio run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install deps
         run: |
           #apt-get install -y python3-pip
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip --break-system-packages
           pip install -U platformio --break-system-packages
       - name: Build
         run: |


### PR DESCRIPTION
Hi @wellenvogel ,

ubuntu-latest was changed from 22.04 to 24.04.
This PR fixes CI pipeline

Regards
free-x