### PR TITLE
feat: added support for RS-485 Modbus wind sensor (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 generated/*
 lib/generated
 webinstall/token.php
+CLAUDE.md
+

--- a/lib/windsensormodbustask/GwWindSensorModbusTask.cpp
+++ b/lib/windsensormodbustask/GwWindSensorModbusTask.cpp
@@ -1,0 +1,70 @@
+#include "GwWindSensorModbusTask.h"
+#include "GwHardware.h"
+#include "WindFunctions.h"
+#include "NMEA0183Messages.h"
+#include "N2kMessages.h"
+
+// Select serial port for wind sensor communication.
+// Can be overridden with -D GWWINDSENSOR_SERIAL=1 or =2 in build flags.
+#ifdef GWWINDSENSOR_SERIAL
+  #if GWWINDSENSOR_SERIAL == 1
+    #define WIND_SERIAL Serial1
+  #elif GWWINDSENSOR_SERIAL == 2
+    #define WIND_SERIAL Serial2
+  #else
+    #error "GWWINDSENSOR_SERIAL must be 1 or 2"
+  #endif
+#else
+  // Auto-select: use first serial port not claimed by the core
+  #if defined(GWSERIAL_TYPE) || defined(GWSERIAL_MODE)
+    #if defined(GWSERIAL2_TYPE) || defined(GWSERIAL2_MODE)
+      #error "Both serial ports are already used by the core - set GWWINDSENSOR_SERIAL explicitly"
+    #else
+      #define WIND_SERIAL Serial2
+    #endif
+  #else
+    #define WIND_SERIAL Serial1
+  #endif
+#endif
+
+void initWindSensorModbusTask(GwApi *api)
+{
+  GwLog *logger = api->getLogger();
+  LOG_DEBUG(GwLog::LOG, "windsensormodbustask initialized");
+  api->addUserTask(runWindSensorModbusTask, "windsensormodbustask", 4000);
+}
+
+void runWindSensorModbusTask(GwApi *api)
+{
+  GwLog *logger = api->getLogger();
+  GwConfigHandler *config = api->getConfig();
+  LOG_DEBUG(GwLog::LOG, "windsensor task started");
+
+  // TODO: Make sure to use the configured COM port, baud rate, address, RX and TX pins, etc.
+  WindFunctions wind(&WIND_SERIAL, 1);
+  wind.begin();
+
+  while (true)
+  {
+    LOG_DEBUG(GwLog::LOG, "Reading wind sensor");
+    if (wind.readAll())
+    {
+      LOG_DEBUG(GwLog::LOG, "Wind speed: %d", wind.WindSpeed);
+      LOG_DEBUG(GwLog::LOG, "Wind scale: %d", wind.WindScale);
+      LOG_DEBUG(GwLog::LOG, "Wind angle: %d", wind.WindAngle);
+      LOG_DEBUG(GwLog::LOG, "Wind direction: %s", wind.getWindDirection());
+
+      tNMEA0183Msg msg;
+      // WindAngle is in 0.1 degree units, WindSpeed is in 0.1 m/s units
+      // NMEA0183SetMWV expects degrees and m/s, sends unit "M" (m/s)
+      NMEA0183SetMWV(msg, wind.WindAngle / 10.0, NMEA0183Wind_Apparent, wind.WindSpeed / 10.0, "WI");
+      api->sendNMEA0183Message(msg);
+      /*       tN2kMsg n2kMsg;
+            SetN2kWindSpeed(n2kMsg, 15, wind.WindSpeed / 10.0, wind.WindAngle / 10.0, tN2kWindReference::N2kWind_Apparent);
+            api->sendN2kMessage(n2kMsg);
+       */
+    }
+    vTaskDelay(1000);
+  }
+  vTaskDelete(NULL);
+}

--- a/lib/windsensormodbustask/GwWindSensorModbusTask.h
+++ b/lib/windsensormodbustask/GwWindSensorModbusTask.h
@@ -1,0 +1,10 @@
+#ifndef _GWINDSENSORMODBUSTASK_H
+#define _GWINDSENSORMODBUSTASK_H
+#include "GwApi.h"
+
+void initWindSensorModbusTask(GwApi *api);
+DECLARE_INITFUNCTION(initWindSensorModbusTask);
+
+void runWindSensorModbusTask(GwApi *api);
+
+#endif // _GWINDSENSORMODBUSTASK_H

--- a/lib/windsensormodbustask/Readme.md
+++ b/lib/windsensormodbustask/Readme.md
@@ -1,0 +1,136 @@
+RS-485 Modbus Wind Sensor Task
+==============================
+
+This directory contains a user task that reads wind speed and direction from an RS-485 Modbus wind sensor and sends the data as NMEA0183 MWV sentences.
+
+## Supported Sensor
+
+**Veinasa XS-WSDS01** — Small Integrated Wind Speed and Direction Sensor (Polycarbonate)
+
+| Parameter                  | Value                                   |
+|----------------------------|-----------------------------------------|
+| Wind Speed Range           | 0–30 m/s (0–60 m/s customizable)        |
+| Wind Direction Range       | 0–360°                                  |
+| Starting Wind Speed        | ≤ 0.3 m/s                               |
+| Accuracy                   | ±(0.3 + 0.03V) m/s, ±1°                |
+| Response Time              | < 1 second                              |
+| Power Supply (RS485 mode)  | 5–24V DC                                |
+| Communication              | RS485 Modbus-RTU, 9600 baud, 8N1        |
+| Default Modbus Address     | 0x01                                    |
+| Working Environment        | 0–50°C, < 95% RH                        |
+| Dimensions                 | 202 × 193 × 101 mm (+ 180 mm arm)       |
+
+The sensor manual is available at `doc/Veinasa XS-WSDS01 Small Integrated Wind Speed and Direction Sensor.pdf`.
+
+The code for reading the sensor has been adapted from [RS485_Arduino_Wind_Direction_Speed_Sensors](https://github.com/wilson-malone/RS485_Arduino_Wind_Direction_Speed_Sensors).
+
+## Required Hardware
+
+You need an RS-485 transceiver to connect the sensor to an ESP32. The reference setup uses:
+
+- **WeMos D1 Mini ESP32** (or compatible ESP32 board)
+- **[TaaraLabs RS-485+CAN Bus+DCDC Shield](https://taaralabs.eu/category/modbus/)** for WeMos D1 Mini32
+  - RS-485 transceiver: THVD1406 with automatic flow control
+  - CAN bus transceiver (for NMEA2000)
+  - DC/DC converter: 3.8V–32V input (12VDC nominal)
+
+## Sensor Wiring
+
+The XS-WSDS01 has 4 wires in RS485 mode:
+
+| Wire Color | Function   |
+|------------|------------|
+| Red        | Power+ (5–24V DC) |
+| Black      | GND        |
+| Yellow     | RS485 A    |
+| Green      | RS485 B    |
+
+Connect the yellow and green wires to the RS-485 transceiver's A and B terminals respectively. Power the sensor with 5–24V DC on the red/black wires.
+
+```
+XS-WSDS01 Sensor          RS-485 Shield            ESP32
++---------------+        +---------------+        +-------+
+| Yellow (A)    |--------| A             |        |       |
+| Green  (B)    |--------| B          TX |--------| RX 16 |
+| Red   (V+)  -|--+     |            RX |--------| TX 17 |
+| Black (GND) -|--+-----| GND       VCC |--------| 3.3V  |
++---------------+  |     +---------------+        +-------+
+                   |
+              5-24VDC supply
+```
+
+## Pin Configuration
+
+The default pins (matching the TaaraLabs RS-485+CAN shield for D1 Mini32):
+
+| Function       | GPIO | Build Flag              |
+|----------------|------|-------------------------|
+| RS-485 RX      | 16   | `GWWINDSENSORMODBUS_RX` |
+| RS-485 TX      | 17   | `GWWINDSENSORMODBUS_TX` |
+| CAN bus RX     | 19   | `ESP32_CAN_RX_PIN`      |
+| CAN bus TX     | 18   | `ESP32_CAN_TX_PIN`      |
+
+To override the default RS-485 pins, set the build flags in your `platformio.ini`:
+
+```ini
+build_flags =
+    -D GWWINDSENSORMODBUS_RX=16
+    -D GWWINDSENSORMODBUS_TX=17
+```
+
+## Serial Port Selection
+
+The task automatically selects an available serial port:
+
+- If `GWSERIAL_TYPE`/`GWSERIAL_MODE` is **not** defined (Serial1 is free) → uses **Serial1**
+- If Serial1 is used by the core but Serial2 is free → uses **Serial2**
+- If both serial ports are used → **compile-time error**
+
+To explicitly select a serial port (e.g., on S3 boards with 3 UARTs), use the `GWWINDSENSOR_SERIAL` build flag:
+
+```ini
+build_flags =
+    -D GWWINDSENSOR_SERIAL=2
+```
+
+## Modbus Protocol
+
+The sensor uses standard Modbus-RTU. The task queries 4 holding registers starting at address 0x0000:
+
+**Query (host → sensor):**
+
+| Byte  | Value  | Description             |
+|-------|--------|-------------------------|
+| 0     | 0x01   | Sensor address          |
+| 1     | 0x03   | Function code (read)    |
+| 2–3   | 0x0000 | Start register address  |
+| 4–5   | 0x0004 | Number of registers     |
+| 6–7   |        | CRC16                   |
+
+**Response (sensor → host):**
+
+| Register | Content             | Unit / Note                   |
+|----------|---------------------|-------------------------------|
+| 0        | Wind Speed          | × 0.1 m/s                    |
+| 1        | Wind Scale          | Beaufort (0–17)               |
+| 2        | Wind Direction Angle| × 0.1 degrees                |
+| 3        | Wind Direction      | 0x00=N, 0x01=NNE, ... 0x0F=NNW (16 compass points) |
+
+## NMEA0183 Output
+
+The task sends **MWV** (Wind Speed and Angle) sentences using the NMEA0183 library's `NMEA0183SetMWV()` function:
+
+- **Wind angle**: 0–360° (apparent/relative), from sensor register 2 (× 0.1°)
+- **Wind speed**: m/s, from sensor register 0 (× 0.1 m/s)
+- **Unit**: "M" (meters per second) — as per the NMEA0183 library convention
+- **Reference**: "R" (apparent wind, relative to vessel)
+- **Talker ID**: "WI" (weather instrument)
+
+Example output: `$WIMWV,135.0,R,3.6,M,A*hh`
+
+## Configuration
+
+The task adds two configuration items (via `windconfig.json`, included via `custom_config`):
+
+- **mbEnable** — Enable/disable the Modbus wind sensor (default: false)
+- **mbAddr** — Modbus address of the sensor (default: 1)

--- a/lib/windsensormodbustask/WindFunctions.cpp
+++ b/lib/windsensormodbustask/WindFunctions.cpp
@@ -1,0 +1,148 @@
+#include "WindFunctions.h"
+#include <Arduino.h>
+
+void WindFunctions::begin(unsigned int baud, int8_t rx, int8_t tx)
+{
+  if (serial)
+    serial->begin(baud, SERIAL_8N1, rx, tx, false, 256);
+}
+
+size_t WindFunctions::readN(uint8_t *buf, size_t len)
+{
+  size_t offset = 0;
+  long start_time = millis(); // Start time for timeout check
+
+  // Wait until enough data is available, with a timeout check
+  while (serial->available() < len)
+  {
+    if (millis() - start_time > 100)
+    {        // 100ms timeout (adjust as needed)
+      break; // Exit if data isn't received within the timeout
+    }
+    delay(1); // Yield to other tasks
+  }
+
+  // Read all available bytes (up to len)
+  while (offset < len && serial->available())
+  {
+    buf[offset] = serial->read();
+    offset++;
+  }
+
+  return offset; // Return the number of bytes successfully read
+}
+
+// Calculate CRC16_2 check value
+// buf: Packet for calculating the check value
+// len: Check the data length
+// return: Return a 16-bit check result
+uint16_t WindFunctions::CRC16_2(uint8_t *buf, int16_t len)
+{
+  uint16_t crc = 0xFFFF;
+  for (int pos = 0; pos < len; pos++)
+  {
+    crc ^= (uint16_t)buf[pos];
+    for (int i = 8; i != 0; i--)
+    {
+      if ((crc & 0x0001) != 0)
+      {
+        crc >>= 1;
+        crc ^= 0xA001;
+      }
+      else
+      {
+        crc >>= 1;
+      }
+    }
+  }
+
+  crc = ((crc & 0x00ff) << 8) | ((crc & 0xff00) >> 8);
+  return crc;
+}
+
+void WindFunctions::addedCRC(uint8_t *buf, int len)
+{
+  uint16_t crc = 0xFFFF;
+  for (int pos = 0; pos < len; pos++)
+  {
+    crc ^= (uint16_t)buf[pos];
+    for (int i = 8; i != 0; i--)
+    {
+      if ((crc & 0x0001) != 0)
+      {
+        crc >>= 1;
+        crc ^= 0xA001;
+      }
+      else
+      {
+        crc >>= 1;
+      }
+    }
+  }
+  buf[len] = crc % 0x100;
+  buf[len + 1] = crc / 0x100;
+}
+
+// Read all the data available from the sensor. 1 parameter is address.
+bool WindFunctions::readAll(uint8_t address)
+{
+  bool bSuccess = false; // Data acquisition success flag
+
+  uint8_t requestData[8] = {0x01, 0x03, 0x00, 0x00, 0x00, 0x04, 0x44, 0x09}; // Command for reading wind speed - this is the original for XS-WSDS01 sensor
+  uint8_t returnData[14] = {0};                                              // Store the original data packet returned by the sensor
+  uint8_t ch = 0;
+
+  requestData[0] = address; // Add the complete command package with reference to the communication protocol.
+  addedCRC(requestData, 6); // Add CRC_16 check for reading wind speed command packet
+  uint8_t retries = 0;
+
+  while (!bSuccess)
+  {
+    if (retries > 2)
+      break;
+
+    // Flush any stale data from the RX buffer to avoid out-of-sync reads
+    while (serial->available())
+      serial->read();
+
+    serial->write(requestData, sizeof(requestData) / sizeof(requestData[0])); // Send the command of reading the wind speed
+    serial->flush();
+    retries++;
+
+    if (readN(&ch, 1) == 1)
+    {
+      if (ch == address) // The first byte is the address of the sensor
+      {
+        returnData[0] = ch;
+        if (readN(&ch, 1) == 1)
+        {
+          if (ch == 0x03) // The second byte is the function code
+          {
+            returnData[1] = ch;
+            if (readN(&ch, 1) == 1)
+            {
+              if (ch == 0x08) // The third byte is data length of all the registers - we have 4 registers, 2 bytes each
+              {
+                returnData[2] = ch;
+                if (readN(&returnData[3], 10) == 10) // Read all the registers
+                {
+                  if (CRC16_2(returnData, 11) == ((returnData[11] << 8) | returnData[12])) // Check CRC of the returned data
+                  {
+                    // Store obtained data
+                    WindSpeed = ((returnData[3] << 8) | returnData[4]);
+                    WindScale = ((returnData[5] << 8) | returnData[6]);
+                    WindAngle = ((returnData[7] << 8) | returnData[8]);
+                    WindDirection = ((returnData[9] << 8) | returnData[10]);
+                    bSuccess = true;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return bSuccess;
+}

--- a/lib/windsensormodbustask/WindFunctions.h
+++ b/lib/windsensormodbustask/WindFunctions.h
@@ -1,0 +1,40 @@
+#ifndef WindFunctions_h
+#define WindFunctions_h
+#include <Arduino.h>
+
+#ifndef GWWINDSENSORMODBUS_RX
+#define GWWINDSENSORMODBUS_RX 16
+#endif
+#ifndef GWWINDSENSORMODBUS_TX
+#define GWWINDSENSORMODBUS_TX 17
+#endif
+
+static const char *const dirList[19] = {"   N", " NNE", "  NE", " ENE", "   E",
+										" ESE", "  SE", " SSE", "   S", " SSW",
+										"  SW", " WSW", "   W", " WNW", "  NW",
+										" NNW", "   N", "INIT", "FAIL"};
+
+// Control RS485 wind direction and speed sensors with arduino.
+class WindFunctions
+{
+public:
+	uint16_t WindSpeed;
+	uint16_t WindScale;
+	uint16_t WindAngle;
+	uint16_t WindDirection;
+
+	WindFunctions(HardwareSerial *s, uint8_t addr) : serial(s), address(addr) {};
+	void begin(unsigned int baud = 9600, int8_t rx = GWWINDSENSORMODBUS_RX, int8_t tx = GWWINDSENSORMODBUS_TX);
+	bool readAll() { return readAll(address); };
+	bool readAll(uint8_t address);
+	const char *const getWindDirection() { return dirList[WindDirection]; };
+
+private:
+	size_t readN(uint8_t *buf, size_t len);
+	uint16_t CRC16_2(uint8_t *buf, int16_t len);
+	void addedCRC(uint8_t *buf, int len);
+	HardwareSerial *serial;
+	uint8_t address;
+};
+
+#endif

--- a/lib/windsensormodbustask/platformio.ini
+++ b/lib/windsensormodbustask/platformio.ini
@@ -1,0 +1,19 @@
+[platformio]
+#if you want a pio run to only build
+#your special environments you can set this here
+#by uncommenting the next line
+#default_envs = lion
+[env:lion]
+board = nodemcu-32s
+custom_config =
+	lib/windsensormodbustask/windconfig.json
+lib_deps =
+	${env.lib_deps}
+build_flags =
+	-D GWWINDSENSORMODBUS_RX=16
+	-D GWWINDSENSORMODBUS_TX=17
+	-D ESP32_CAN_RX_PIN=19
+	-D ESP32_CAN_TX_PIN=18
+	${env.build_flags}
+upload_port = /dev/ttyACM0
+upload_protocol = esptool

--- a/lib/windsensormodbustask/windconfig.json
+++ b/lib/windsensormodbustask/windconfig.json
@@ -1,0 +1,24 @@
+[
+    {
+        "name": "mbEnable",
+        "label": "enable modbus wind sensor",
+        "type": "boolean",
+        "default": "false",
+        "description": "Enable support for modbus serial port wind sensor XS-WSDS01",
+        "category": "modbus serial port",
+        "capabilities": {
+            "modbusserial": "true"
+        }
+    },
+    {
+        "name": "mbAddr",
+        "label": "modbus sensor address",
+        "type": "number",
+        "default": 1,
+        "description": "The modbus address of the wind sensor",
+        "category": "modbus serial port",
+        "capabilities": {
+            "modbusserial": "true"
+        }
+    }
+]


### PR DESCRIPTION
## Summary

Adds support for RS-485 Modbus wind sensors as a separate user task. The reference sensor is the **Veinasa XS-WSDS01** Small Integrated Wind Speed and Direction Sensor.

The task reads wind speed and direction over Modbus RTU and sends NMEA0183 MWV sentences using the `NMEA0183SetMWV()` library function (wind speed in m/s, apparent wind reference).

### Hardware

- Reference board: WeMos D1 Mini ESP32 with [TaaraLabs RS-485+CAN Bus+DCDC Shield](https://taaralabs.eu/category/modbus/)
- Default pins: RS-485 RX=GPIO16, TX=GPIO17; CAN RX=GPIO19, TX=GPIO18

### Features

- Automatic serial port selection (Serial1/Serial2) based on core usage, with `GWWINDSENSOR_SERIAL` build flag for explicit override
- Configuration via `custom_config` (only included for relevant environments)
- Comprehensive Readme.md with sensor specs, wiring diagram, Modbus protocol details

### Files

- `lib/windsensormodbustask/` — task implementation, config, and documentation